### PR TITLE
bottom panel slider regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,9 +878,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecolor"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137c0ce4ce4152ff7e223a7ce22ee1057cdff61fce0a45c32459c3ccec64868d"
+checksum = "55f6cc0cb3b84a21232c468db972ebcddd34decbf1ff02cdebffd807c13bbd81"
 dependencies = [
  "bytemuck",
  "emath",
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e995b8e434d65aefd12c4519221be3e8f38efd77804ef39ca10553f4ad7063"
+checksum = "fea3080bfd001aee2223dcb2228d9de7d31f41d7cfb99e8cd70df3ae8083a42f"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34aaf627da598dfadd64b0fee6101d22e9c451d1e5348157312720b7f459f0f"
+checksum = "3cbe28ac1a9c0761319aafb9ad37737720cc49d99c13a4a6b990768fa01ffe67"
 dependencies = [
  "accesskit",
  "ahash",
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71033ff78b041c9c363450f4498ff95468ef3ecbcc71a62f67036a6207d98fa4"
+checksum = "2f311c0b9cdd8a38821ae6f245fbe6e1a3d7d157c77b7d22344f205b317232c8"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a2881b2bf1a305e413e644af63f836737a33d85077705ff808e88f902ff742"
+checksum = "e8e97625c2fe0fadc8b92ec690fbf515e15e2efd67ca50e063ad3302ec8ee626"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b28d39ab6c0cac238190e6cb1e8c9047d02cb470ab942a7a3302e4cb3a8e74"
+checksum = "6caa4eca47cc2358e2c5ae60843a94118e338f87099c6af4170e6e968e8d77cb"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1014,9 +1014,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a05cd8bdf3b598488c627ca97c7fe8909448ffa26278dd3c7e535cdb554d721"
+checksum = "a74fbbf7501c430b89df62d102b6bfa02162faaf3e155512c677c9d20f5708d1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f3017dd67f147a697ee0c8484fb568fd9553e2a0c114be5020dbbc11962841"
+checksum = "92b452e348c2758115288802ca25f86ee286ce2cfae6643711ce116662311310"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1085,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3b85a2bb775a3ab02d077a65cc31575c11b2584581913253cc11ce49f48bba"
+checksum = "1644e25dbe3d663fd9c2a4181772c64b23361e377e550c10422ecc3a7de1c3c2"
 
 [[package]]
 name = "equivalent"
@@ -3533,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "vapoursynth"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9316c850f56e0d2e4a6fc149c83fbcaf3ccae7deb627b33664839ee166bb01cf"
+checksum = "413b994d9955202f99298ef502dec6d84f1be7603483d19158a365f9fdb8f128"
 dependencies = [
  "anyhow",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive", "wrap_help", "deprecated"] }
-eframe = { version = "0.34.1", features = ["persistence"] }
+eframe = { version = "0.34.2", features = ["persistence"] }
 fast_image_resize = "6.0.0"
 image = { version = "0.25.10", default-features = false, features = ["png"] }
 rgb = "0.8.53"
@@ -23,7 +23,7 @@ poll-promise = "0.3.0"
 rfd = "0.17.2"
 serde_derive = "1.0.228"
 serde = "1.0.228"
-vapoursynth = { version = "0.5.4" }
+vapoursynth = { version = "0.5.6" }
 
 [[bin]]
 name = "vspreview-rs"

--- a/src/app/ui/bottom_panel.rs
+++ b/src/app/ui/bottom_panel.rs
@@ -11,55 +11,63 @@ impl UiBottomPanel {
             .get_mut(&pv.state.cur_output)
             .ok_or_else(|| anyhow!("UiBottomPanel::ui: Invalid current output key"))?;
         let node_info = &output.vsoutput.node_info;
+        let width = ui.available_width();
+        egui::Area::new(egui::Id::new("bottom_slider_overlay"))
+            .anchor(egui::Align2::LEFT_BOTTOM, egui::Vec2::ZERO)
+            .order(egui::Order::Foreground)
+            .default_width(width)
+            .default_height(65.0)
+            .show(ui.ctx(), |ui| {
+                let transparent_frame = egui::Frame::default()
+                    .fill(Color32::from_black_alpha(96))
+                    .inner_margin(MarginF32 {
+                        left: 20.0,
+                        right: 20.0,
+                        top: 10.0,
+                        bottom: 10.0,
+                    });
+                ui.set_min_width(width);
+                ui.set_max_width(width);
+                egui::Panel::bottom("BottomInfo")
+                    .frame(transparent_frame)
+                    .show_inside(ui, |ui| {
+                        // Add slider
+                        ui.spacing_mut().slider_width = 600.0;
+                        let mut slider_frame_no = pv.state.cur_frame_no;
 
-        let transparent_frame = egui::Frame::default()
-            .fill(Color32::from_black_alpha(96))
-            .inner_margin(MarginF32 {
-                left: 20.0,
-                right: 20.0,
-                top: 10.0,
-                bottom: 10.0,
-            });
+                        // We want a bit more precision to within ~50 frames
+                        let frames_slider =
+                            egui::Slider::new(&mut slider_frame_no, 0..=(node_info.num_frames - 1))
+                                .smart_aim(false)
+                                .integer();
 
-        egui::Panel::bottom("BottomInfo")
-            .frame(transparent_frame)
-            .show_inside(ui, |ui| {
-                // Add slider
-                ui.spacing_mut().slider_width = 600.0;
+                        let slider_res = ui.add(frames_slider);
+                        let in_use = slider_res.has_focus() || slider_res.drag_started();
+                        let lost_focus = update_input_key_state(
+                            &mut pv.inputs_focused,
+                            "frame_slider",
+                            in_use,
+                            &slider_res,
+                        );
 
-                let mut slider_frame_no = pv.state.cur_frame_no;
+                        // Released/changed value
+                        if lost_focus {
+                            output.last_frame_no = pv.state.cur_frame_no;
+                            pv.state.cur_frame_no = slider_frame_no;
 
-                // We want a bit more precision to within ~50 frames
-                let frames_slider =
-                    egui::Slider::new(&mut slider_frame_no, 0..=(node_info.num_frames - 1))
-                        .smart_aim(false)
-                        .integer();
+                            pv.rerender = true;
+                        } else if slider_frame_no != pv.state.cur_frame_no {
+                            pv.state.cur_frame_no = slider_frame_no;
+                        }
 
-                let slider_res = ui.add(frames_slider);
-                let in_use = slider_res.has_focus() || slider_res.drag_started();
-                let lost_focus = update_input_key_state(
-                    &mut pv.inputs_focused,
-                    "frame_slider",
-                    in_use,
-                    &slider_res,
-                );
+                        let output_info =
+                            format!("Output {} - {}", output.vsoutput.index, node_info);
 
-                // Released/changed value
-                if lost_focus {
-                    output.last_frame_no = pv.state.cur_frame_no;
-                    pv.state.cur_frame_no = slider_frame_no;
-
-                    pv.rerender = true;
-                } else if slider_frame_no != pv.state.cur_frame_no {
-                    pv.state.cur_frame_no = slider_frame_no;
-                }
-
-                let output_info = format!("Output {} - {}", output.vsoutput.index, node_info);
-
-                let node_info_label = egui::RichText::new(output_info)
-                    .color(Color32::from_gray(200))
-                    .size(20.0);
-                ui.label(node_info_label);
+                        let node_info_label = egui::RichText::new(output_info)
+                            .color(Color32::from_gray(200))
+                            .size(20.0);
+                        ui.label(node_info_label);
+                    });
             });
 
         Ok(())


### PR DESCRIPTION
The 1.0.2 release [change](https://github.com/quietvoid/vspreview-rs/commit/d83a18860ee3729a610770c7923595a857e49a75#diff-e05e42ea073e4d6a7256f2956d2a3d90c4398d28027c9fecb052d03ecb9373e5R26) no longer renders the transparent bottom overlay slider panel for me. If I change the bottom panel to use the deprecated `.show` again (instead of `.show_inside`) it renders correctly at the top level. To simulate the previous behaviour I instead added an anchored `Area` overlay sized to the ui width. 

Also updated vapoursynth and eframe.

Feel free to comment or close. 